### PR TITLE
Fixed bug in Example 6.7 - startAnimation()

### DIFF
--- a/ch06/example-6.7/example.js
+++ b/ch06/example-6.7/example.js
@@ -73,7 +73,7 @@ function pauseAnimation() {
 function startAnimation() {
    animateButton.value = 'Pause';
    paused = false;
-   lastAdvance = +new Date();
+   lastAdvance = 0;
    window.requestNextAnimationFrame(animate);
 }
 


### PR DESCRIPTION
Bug in startAnimation() prevents the animation from running in Chrome and IE.

Changed: lastAdvance = +new Date(); 
to:      lastAdvance = 0;
