### PR TITLE
fix bug section-8.3

### DIFF
--- a/ch08/section-8.3/example.js
+++ b/ch08/section-8.3/example.js
@@ -367,7 +367,9 @@ canvas.onmousemove = function (e) {
 
 // Animation Loop................................................
 
-function animate(time) {
+function animate() {
+   var time = Date.now();
+
    elapsedTime = (time - launchTime) / 1000;
    context.clearRect(0,0,canvas.width,canvas.height);
 
@@ -423,4 +425,4 @@ bucketImage.onload = function (e) {
    bucket.height = BUCKET_HEIGHT;
 };
 
-animate(+new Date());
+animate();


### PR DESCRIPTION
callback argument of requestAnimationFrame is a `DOMHighResTimeStamp` (`!== +new Date()`),
I changed to run `Date.now()` at the beginning of the animate function.

refs https://developer.mozilla.org/en/docs/Web/API/Window/requestAnimationFrame#Parameters
